### PR TITLE
use sudo instead of setuid in upstart script

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,6 +83,7 @@ when "debian"
     variables(
       :dir              => node["logstash-forwarder"]["dir"],
       :user             => node["logstash-forwarder"]["user"],
+      :group            => node["logstash-forwarder"]["group"],
       :log_dir          => node["logstash-forwarder"]["log_dir"],
       :config_file      => node["logstash-forwarder"]["config_file"]
     )

--- a/templates/default/logstash-forwarder.conf.erb
+++ b/templates/default/logstash-forwarder.conf.erb
@@ -8,10 +8,9 @@ respawn
 respawn limit 5 30
 
 chdir <%= @dir %>
-setuid <%= @user %>
 
 script
-  exec <%= @dir %>/bin/logstash-forwarder.sh -config <%= @config_file %> >> <%= @log_dir %>/logstash-forwarder.log 2>&1
+  exec sudo -u <%= @user %> <%= @dir %>/bin/logstash-forwarder.sh -config <%= @config_file %> >> <%= @log_dir %>/logstash-forwarder.log 2>&1
 end script
 
 emits logstash-forwarder-running


### PR DESCRIPTION
A common method for granting access to the logstash-forwarder user for various logfiles is to add the user to a secondary group (e.g. `adm` for syslog). Unfortunately, `setuid` in upstart only runs as the primary group, not secondary groups.

The fix is to use sudo instead.
